### PR TITLE
test: Comprehensive edge case tests for token & marketplace (#19)

### DIFF
--- a/test/ARTICLMarketplace.t.sol
+++ b/test/ARTICLMarketplace.t.sol
@@ -327,11 +327,13 @@ contract ARTICLMarketplaceTest is Test {
             ARTICLMarketplace.SignedCall({buyer: buyer, apiId: apiId, amount: 1000, nonce: nonce, signature: ""});
         c.signature = _sign(c, buyerKey);
 
+        uint256 publisherBalanceBefore = token.balanceOf(publisher);
+
         vm.prank(publisher);
         market.redeemCall(c);
 
         assertTrue(market.usedNonces(buyer, nonce));
-        assertEq(token.balanceOf(publisher), 1000);
+        assertEq(token.balanceOf(publisher), publisherBalanceBefore + 1000);
     }
 
     // ============ Edge Case: registerApi ============

--- a/test/ARTICLToken.t.sol
+++ b/test/ARTICLToken.t.sol
@@ -133,6 +133,10 @@ contract ARTICLTokenTest is Test {
         // ETH backing invariant: contract holds exactly what's needed
         uint256 ethRequired = (expectedMinted * 1 ether) / 1e8;
         assertEq(address(token).balance, ethRequired, "ETH backing mismatch");
+
+        // Dust that cannot mint a full token should be refunded to minter
+        uint256 refund = ethAmount - ethRequired;
+        assertEq(alice.balance, refund, "refund amount mismatch");
     }
 
     /// @dev Mint refund logic: ETH that doesn't divide evenly should refund dust


### PR DESCRIPTION
## Summary
Closes #19 — adds **33 new tests** (14 → 47 total), all passing.

### Token tests added:
- **Fuzz tests**: mint varying amounts, redeem varying amounts, ETH backing invariant
- **Boundary tests**: 9 gwei (revert) vs 10 gwei (1 token), mint refund dust
- **Revert tests**: mint to zero, redeem zero/exceeding/to-zero, transfer exceeding balance
- **Edge cases**: mint to different recipient, redeem entire balance (supply→0), max allowance not decreased, receive() reverts

### Marketplace tests added:
- **Revert tests**: redeemCall exceeding balance, non-existent API, zero amount, wrong signer, invalid sig length
- **updateApi**: non-publisher revert, non-existent revert, success case
- **Batch edge cases**: empty array no-op, single element, multiple publishers/APIs
- **Fuzz**: random nonce values (256 runs)
- **Gas snapshots**: single redeemCall (~84k gas) vs batch of 2 (~167k gas)

### Checklist from #19:
- [x] Fuzz: mint with varying ETH amounts
- [x] Fuzz: redeem with varying amounts  
- [x] Mint refund logic (non-even division)
- [x] Redeem entire balance (totalSupply→0)
- [x] Multiple minters invariant check
- [x] receive() reverts
- [x] Mint to different address
- [x] Invariant: ETH backing always matches totalSupply
- [x] redeemCall exceeding balance
- [x] redeemCall non-existent apiId
- [x] updateApi by non-publisher / non-existent
- [x] redeemCalls empty array
- [x] redeemCalls single element
- [x] Batch with multiple APIs/publishers
- [x] Invalid signature length
- [x] Fuzz: random nonce values
- [x] Gas snapshots
