### PR TITLE
ci: add gas snapshot artifact generation (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Run Forge tests
         run: forge test -vvv
 
+      - name: Generate gas snapshot
+        run: forge snapshot
+
+      - name: Upload gas snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forge-gas-report
+          path: .gas-snapshot
+
   client-sdk-tests:
     name: Client SDK Tests (Vitest)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add `forge snapshot` to CI solidity job
- upload `.gas-snapshot` as CI artifact for PR-to-PR comparison
- keep existing `forge build --sizes` contract size visibility

## Why
Issue #16 asks for CI gas snapshots + size checks. Size checks are already present via `forge build --sizes`; this PR adds the missing gas snapshot path.

Closes #16
