### PR TITLE
docs: runnable publisher integration guide + env-ready example server (#17)

### DIFF
--- a/PUBLISHER_INTEGRATION.md
+++ b/PUBLISHER_INTEGRATION.md
@@ -1,0 +1,180 @@
+# Publisher Integration Guide (ARTICL)
+
+This guide turns the `examples/` scaffolding into a runnable publisher flow.
+
+> **North Star alignment:** This directly advances **Top Priority #2 — “🔌 End-to-End Publisher Flow”** from `NORTHSTAR.md` by making one real publisher path easy to stand up and validate.
+
+## What you will run
+
+- An API server (`examples/publisher-server.ts`) with ARTICL middleware
+- Signature verification for incoming `Call` payloads
+- Optional automatic on-chain redemption (`redeemCall`)
+
+## Prerequisites
+
+- Node.js 20+
+- An RPC URL (local Anvil or Base Sepolia)
+- Deployed contract addresses:
+  - `ARTICL` token
+  - `ARTICLMarketplace`
+- A publisher wallet private key (for `registerApi` / optional `autoRedeem`)
+
+---
+
+## 1) Install dependencies
+
+From repo root:
+
+```bash
+npm install
+```
+
+If your setup does not install root deps, install the minimum runtime set:
+
+```bash
+npm install express ethers tsx
+npm install -D typescript @types/express
+```
+
+---
+
+## 2) Configure environment
+
+Create `.env.publisher` in repo root:
+
+```bash
+RPC_URL=http://localhost:8545
+PORT=3000
+MARKETPLACE_ADDRESS=0xYourMarketplace
+TOKEN_ADDRESS=0xYourToken
+PUBLISHER_PRIVATE_KEY=0xYourPrivateKey
+AUTO_REDEEM=true
+```
+
+Notes:
+
+- `AUTO_REDEEM=true`: middleware redeems valid calls immediately.
+- `AUTO_REDEEM=false`: server verifies only; you can batch redeem later.
+
+---
+
+## 3) (Optional) Register your API to get `apiId`
+
+Use a quick script/console call with your publisher signer:
+
+```ts
+import { ethers } from "ethers";
+import marketplaceAbi from "./client-sdk/src/abi.marketplace.json";
+
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL!);
+const signer = new ethers.Wallet(process.env.PUBLISHER_PRIVATE_KEY!, provider);
+const marketplace = new ethers.Contract(process.env.MARKETPLACE_ADDRESS!, marketplaceAbi, signer);
+
+const tx = await marketplace.registerApi(
+  "Weather API",
+  "ipfs://weather-api-metadata",
+  25_000_000n // 0.25 ETH worth of ARTICL units at 1e8/ETH
+);
+await tx.wait();
+```
+
+Capture emitted `apiId` from `ApiRegistered` event.
+
+---
+
+## 4) Start publisher server
+
+`examples/publisher-server.ts` currently has placeholder constants; replace those with env lookups before running:
+
+```ts
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL || "http://localhost:8545");
+const publisherSigner = new ethers.Wallet(process.env.PUBLISHER_PRIVATE_KEY!, provider);
+
+const MARKETPLACE_ADDRESS = process.env.MARKETPLACE_ADDRESS!;
+const TOKEN_ADDRESS = process.env.TOKEN_ADDRESS!;
+const PORT = Number(process.env.PORT || 3000);
+```
+
+Then run:
+
+```bash
+set -a; source .env.publisher; set +a
+npx tsx examples/publisher-server.ts
+```
+
+Expected startup:
+
+```text
+🚀 ARTICL publisher server running on http://localhost:3000
+```
+
+---
+
+## 5) Send a signed call from buyer
+
+Use `ARTICLClient` on buyer side:
+
+```ts
+const signed = await client.signCall({
+  apiId: 1n,
+  amount: 25_000_000n,
+  nonce: 1n,
+});
+
+await fetch("http://localhost:3000/api/data", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(signed),
+});
+```
+
+Middleware checks:
+
+1. payload shape present
+2. API allowlist (if configured)
+3. EIP-712 signature recovers `buyer`
+4. local digest equals `marketplace.hashCall(...)`
+5. buyer allowance + balance sanity checks
+6. optional on-chain `redeemCall`
+
+Success response from protected endpoint:
+
+```json
+{ "data": "Premium data", "ts": 1700000000000 }
+```
+
+---
+
+## 6) Troubleshooting
+
+### `Missing ARTICL payload`
+Your JSON body is missing one of: `buyer`, `apiId`, `amount`, `nonce`, `signature`.
+
+### `Invalid signature` / `Digest mismatch`
+Most common causes:
+- wrong `chainId`
+- wrong `verifyingContract` (marketplace address)
+- buyer signed a different `(apiId, amount, nonce)`
+
+### `Insufficient allowance or balance`
+Buyer must:
+- mint enough ARTICL
+- approve marketplace for at least `amount`
+
+### Redeem transaction reverts
+Check:
+- nonce already used
+- payload signed for another marketplace/domain
+- buyer approval changed since pre-check
+
+---
+
+## Production recommendations
+
+- Keep `AUTO_REDEEM=false` for high throughput APIs and batch with `redeemCalls`.
+- Add idempotency keys in your HTTP layer to avoid duplicate work.
+- Persist accepted call payloads and redemption tx hashes for auditability.
+- Use queue + retry workers for on-chain submission.
+- Add monitoring for redeem failures and nonce-reuse attempts.
+
+This keeps API latency low while preserving the North Star architecture direction: **“Off-chain verification, on-chain settlement.”**

--- a/PUBLISHER_INTEGRATION.md
+++ b/PUBLISHER_INTEGRATION.md
@@ -73,7 +73,7 @@ const marketplace = new ethers.Contract(process.env.MARKETPLACE_ADDRESS!, market
 const tx = await marketplace.registerApi(
   "Weather API",
   "ipfs://weather-api-metadata",
-  25_000_000n // 0.25 ETH worth of ARTICL units at 1e8/ETH
+  25_000_000n // 0.25 ETH worth of ARTICL units (1e8 ARTICL units per ETH)
 );
 await tx.wait();
 ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ const signed = await client.signCall({ apiId: 1n, amount: 25_000_000n, nonce: 1n
 
 See `examples/publisher-middleware.ts` and `examples/publisher-server.ts` for an Express middleware that performs the verification and optionally redeems on-chain.
 
+For a full runnable setup, read `PUBLISHER_INTEGRATION.md`.
+
 ## Client SDK highlights (`client-sdk/src/ARTICLClient.ts`)
 - `mint`, `redeem`, `approveMarketplace`, `balanceOf`, `allowance`
 - `registerApi`, `updateApi`, `redeemCallOnChain`, `redeemCallsOnChain`

--- a/examples/publisher-server.ts
+++ b/examples/publisher-server.ts
@@ -31,8 +31,8 @@ if (!process.env.MARKETPLACE_ADDRESS || !process.env.TOKEN_ADDRESS) {
 
 const publisherSigner = new ethers.Wallet(process.env.PUBLISHER_PRIVATE_KEY, provider);
 
-const MARKETPLACE_ADDRESS = process.env.MARKETPLACE_ADDRESS; // deployed marketplace
-const TOKEN_ADDRESS = process.env.TOKEN_ADDRESS; // deployed ARTICL token
+const MARKETPLACE_ADDRESS = process.env.MARKETPLACE_ADDRESS!; // deployed marketplace
+const TOKEN_ADDRESS = process.env.TOKEN_ADDRESS!; // deployed ARTICL token
 
 // Parse JSON bodies
 app.use(express.json());

--- a/examples/publisher-server.ts
+++ b/examples/publisher-server.ts
@@ -16,14 +16,23 @@ import { ethers } from "ethers";
 import { createARTICLMiddleware } from "./publisher-middleware";
 
 const app = express();
-const PORT = 3000;
+const PORT = Number(process.env.PORT || 3000);
 
 // Setup provider and signer (publisher signs redeemCall)
-const provider = new ethers.JsonRpcProvider("http://localhost:8545");
-const publisherSigner = new ethers.Wallet("YOUR_PUBLISHER_PRIVATE_KEY", provider);
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL || "http://localhost:8545");
 
-const MARKETPLACE_ADDRESS = "0x..."; // deployed marketplace
-const TOKEN_ADDRESS = "0x..."; // deployed ARTICL token
+if (!process.env.PUBLISHER_PRIVATE_KEY) {
+  throw new Error("Missing PUBLISHER_PRIVATE_KEY env var");
+}
+
+if (!process.env.MARKETPLACE_ADDRESS || !process.env.TOKEN_ADDRESS) {
+  throw new Error("Missing MARKETPLACE_ADDRESS or TOKEN_ADDRESS env vars");
+}
+
+const publisherSigner = new ethers.Wallet(process.env.PUBLISHER_PRIVATE_KEY, provider);
+
+const MARKETPLACE_ADDRESS = process.env.MARKETPLACE_ADDRESS; // deployed marketplace
+const TOKEN_ADDRESS = process.env.TOKEN_ADDRESS; // deployed ARTICL token
 
 // Parse JSON bodies
 app.use(express.json());
@@ -34,7 +43,7 @@ const articlMiddleware = createARTICLMiddleware({
   tokenAddress: TOKEN_ADDRESS,
   provider,
   signer: publisherSigner,
-  autoRedeem: true,
+  autoRedeem: process.env.AUTO_REDEEM !== "false",
   onRequest: (payload) => console.log(`📥 Call from ${payload.buyer} for api ${payload.apiId}`),
   onValid: (payload) => console.log(`✅ Authorized call nonce ${payload.nonce}`),
   onInvalid: (reason, payload) => console.log(`❌ Rejected call: ${reason}`, payload),


### PR DESCRIPTION
## Summary
This PR converts the existing publisher examples into a runnable path and adds a dedicated integration guide.

### What changed
- Added `PUBLISHER_INTEGRATION.md` with step-by-step setup (env, startup, signing flow, troubleshooting, production notes).
- Updated `examples/publisher-server.ts` to use environment variables instead of hardcoded placeholders.
- Added README pointer to the new guide.

## North Star reference
This PR explicitly embodies **NORTHSTAR.md → Top 3 Priorities → "2. 🔌 End-to-End Publisher Flow"**:
> "Build a working publisher that accepts signed calls, verifies, serves an API response, and redeems on-chain."

It also follows **Architecture Direction**:
> "Off-chain verification, on-chain settlement".

## Issue
Closes #17
